### PR TITLE
Fix Tailwind base styles to restore stable build

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,10 @@
 
 @layer base {
   body {
-    @apply bg-slate-950 text-white antialiased;
+    background-color: rgb(2 6 23);
+    color: #ffffff;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the Tailwind @apply usage in the base stylesheet with plain CSS so the Tailwind compiler no longer errors on unknown utilities
- keep the dark theme body styling by explicitly setting the background color, text color, and font smoothing properties

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51cb259148326bb3f15fdca7fe658